### PR TITLE
Gate SSE functionality behind Cargo feature

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -28,6 +28,10 @@ keywords = ["async", "mcp", "protocol", "daemon", "extended"]
 categories = ["asynchronous", "development-tools", "web-programming::http-client", "web-programming::http-server", "web-programming::websocket"]
 readme = "README.md"
 
+[features]
+default = ["sse"]
+sse = ["dep:actix-web-lab"]
+
 [dependencies]
 tokio = { version = "1.0", features = ["full", "test-util"] }
 serde = { version = "1.0", features = ["derive"] }
@@ -44,7 +48,7 @@ futures = "0.3"
 jsonwebtoken = "8.1"
 uuid = { version = "1.0", features = ["v4"] }
 actix-ws = "0.2.5"
-actix-web-lab = "0.20"
+actix-web-lab = { version = "0.20", optional = true }
 actix-cors = "0.6"
 rustls = "0.20"
 rustls-pemfile = "1.0"

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -43,7 +43,9 @@ pub mod registry;
 pub mod server;
 
 /// Server-Sent Events (SSE) implementation for real-time communication
+#[cfg(feature = "sse")]
 pub mod sse;
+#[cfg(feature = "sse")]
 pub use sse::http_server::run_http_server;
 
 /// Transport layer implementations for different communication protocols

--- a/src/transport/http_transport.rs
+++ b/src/transport/http_transport.rs
@@ -3,6 +3,7 @@
 
 use super::{Message, Result, Transport};
 use super::ws_transport::{ClientWsTransport, ServerWsTransport};
+#[cfg(feature = "sse")]
 use super::sse_transport::ServerSseTransport;
 use async_trait::async_trait;
 
@@ -10,6 +11,7 @@ use async_trait::async_trait;
 #[derive(Debug, Clone)]
 pub enum ServerHttpTransport {
     /// Server-Sent Events transport
+    #[cfg(feature = "sse")]
     Sse(ServerSseTransport),
     /// WebSocket transport
     Ws(ServerWsTransport),
@@ -26,6 +28,7 @@ pub enum ClientHttpTransport {
 impl Transport for ServerHttpTransport {
     async fn send(&self, message: &Message) -> Result<()> {
         match self {
+            #[cfg(feature = "sse")]
             Self::Sse(transport) => transport.send(message).await,
             Self::Ws(transport) => transport.send(message).await,
         }
@@ -33,6 +36,7 @@ impl Transport for ServerHttpTransport {
 
     async fn receive(&self) -> Result<Option<Message>> {
         match self {
+            #[cfg(feature = "sse")]
             Self::Sse(transport) => transport.receive().await,
             Self::Ws(transport) => transport.receive().await,
         }
@@ -40,6 +44,7 @@ impl Transport for ServerHttpTransport {
 
     async fn open(&self) -> Result<()> {
         match self {
+            #[cfg(feature = "sse")]
             Self::Sse(transport) => transport.open().await,
             Self::Ws(transport) => transport.open().await,
         }
@@ -47,6 +52,7 @@ impl Transport for ServerHttpTransport {
 
     async fn close(&self) -> Result<()> {
         match self {
+            #[cfg(feature = "sse")]
             Self::Sse(transport) => transport.close().await,
             Self::Ws(transport) => transport.close().await,
         }

--- a/src/transport/mod.rs
+++ b/src/transport/mod.rs
@@ -15,7 +15,9 @@ mod stdio_transport;
 pub use stdio_transport::*;
 mod inmemory_transport;
 pub use inmemory_transport::*;
+#[cfg(feature = "sse")]
 mod sse_transport;
+#[cfg(feature = "sse")]
 pub use sse_transport::*;
 mod ws_transport;
 pub use ws_transport::*;


### PR DESCRIPTION
Looking to use this library but it pulls in actix-web-lab which pulls in tracing with the log feature, which is incompatible with my source tree. I don't think I need SSE, would appreciate if it could be gated behind a feature flag.

## Summary by Sourcery

Adds a Cargo feature flag to enable or disable SSE functionality.