### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ Add this to your `Cargo.toml`:
 
 ```toml
 [dependencies]
-mcp-daemon = "0.2.1"
+mcp_daemon = "0.2.1"
 ```
 
 ## Overview


### PR DESCRIPTION
When using Cargo to pull the crate, it fails to find mcp-daemon. In your Cargo.toml, the crate should be referenced as mcp_daemon (using an underscore) instead of a hyphen.

## Summary by Sourcery

Documentation:
- Update the README to use an underscore instead of a hyphen in the crate name.